### PR TITLE
Remove unnecessary require

### DIFF
--- a/webpack.config-helper.js
+++ b/webpack.config-helper.js
@@ -5,7 +5,6 @@ const Webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ExtractSASS = new ExtractTextPlugin('styles/bundle.css');
-const webpack = require('webpack');
 
 module.exports = (options) => {
   const dest = Path.join(__dirname, 'dist');


### PR DESCRIPTION
`webpack` is required twice: as `Webpack` and `webpack`. The latter is never used.