### PR TITLE
Minify CSS in production

### DIFF
--- a/webpack.config-helper.js
+++ b/webpack.config-helper.js
@@ -57,7 +57,7 @@ module.exports = (options) => {
 
     webpackConfig.module.rules.push({
       test: /\.scss$/i,
-      use: ExtractSASS.extract(['css-loader', 'sass-loader'])
+      use: ExtractSASS.extract(['css-loader?minimize=true', 'sass-loader'])
     });
 
   } else {


### PR DESCRIPTION
Minify the CSS bundle in production, using the `minimize` option of the `css-loader`.