### PR TITLE
Load .css files

### DIFF
--- a/webpack.config-helper.js
+++ b/webpack.config-helper.js
@@ -56,7 +56,7 @@ module.exports = (options) => {
     );
 
     webpackConfig.module.rules.push({
-      test: /\.scss$/i,
+      test: /\.s?css$/i,
       use: ExtractSASS.extract(['css-loader', 'sass-loader'])
     });
 
@@ -66,7 +66,7 @@ module.exports = (options) => {
     );
 
     webpackConfig.module.rules.push({
-      test: /\.scss$/i,
+      test: /\.s?css$/i,
       use: ['style-loader', 'css-loader', 'sass-loader']
     }, {
       test: /\.js$/,


### PR DESCRIPTION
Modify the test regex for the CSS loader, so that it will match both `.scss` *and* `.css` files.
Since CSS *is* valid SCSS, no further modification is required.
Without this modification, it's not possible to import third-party CSS modules, e.g., `normalize.css`.