### PR TITLE
Minify HTML in production

### DIFF
--- a/webpack.config-helper.js
+++ b/webpack.config-helper.js
@@ -25,7 +25,15 @@ module.exports = (options) => {
         }
       }),
       new HtmlWebpackPlugin({
-        template: './src/index.html'
+        template: './src/index.html',
+        minify: options.isProduction && {
+          collapseWhitespace: true,
+          conservativeCollapse: true,
+          decodeEntities: true,
+          minifyCSS: true,
+          minifyJS: true,
+          removeComments: true
+        }
       })
     ],
     module: {


### PR DESCRIPTION
Minify HTML in production, using the `minify` option of the `html-webpack-plugin`.
This will:
- Conservatively collapse white space (i.e., leave one single space),
- Decode HTML entities to Unicode characters whenever possible,
- Minify inline CSS & JS, and
- Strip HTML comments.