### PR TITLE
Fix CSS source map

### DIFF
--- a/webpack.config-helper.js
+++ b/webpack.config-helper.js
@@ -56,7 +56,7 @@ module.exports = (options) => {
 
     webpackConfig.module.rules.push({
       test: /\.s?css/i,
-      use: ExtractSASS.extract(['css-loader?minimize=true', 'sass-loader'])
+      use: ExtractSASS.extract(['css-loader?minimize=true&sourceMap=true', 'sass-loader'])
     });
 
   } else {


### PR DESCRIPTION
Set `sourceMap` option of the `css-loader` to `true` to fix the CSS source map.
Without this option, the generated map file will be empty.